### PR TITLE
Changed canvas flag in order to resolve crash in Android 9.0 operating system.

### DIFF
--- a/circleimageview/src/main/java/com/zuowei/circleimageview/CircleImageView.java
+++ b/circleimageview/src/main/java/com/zuowei/circleimageview/CircleImageView.java
@@ -133,7 +133,7 @@ public class CircleImageView extends ImageView {
     protected void onDraw(Canvas canvas) {
         syncDrawableIf();
         if (drawableSettled) {
-            int layerID = canvas.saveLayer(layerRect, layerPaint, Canvas.CLIP_SAVE_FLAG);//clear background
+            int layerID = canvas.saveLayer(layerRect, layerPaint, Canvas.ALL_SAVE_FLAG);//clear background
                 circlePath.reset();
                 circlePath.addCircle(layerRect.centerX(), layerRect.centerY(), radius, Path.Direction.CCW);
                 canvas.clipPath(circlePath);


### PR DESCRIPTION
Resolved crash faced in android 9.0 os. Please refer crash report in the following issue. https://github.com/zuoweitan/CircleImageView/issues/4.